### PR TITLE
타겟 페이지와 연동

### DIFF
--- a/module/queue/src/main/java/cwchoiit/ticketing/queue/controller/UserQueueController.java
+++ b/module/queue/src/main/java/cwchoiit/ticketing/queue/controller/UserQueueController.java
@@ -35,8 +35,9 @@ public class UserQueueController {
 
     @GetMapping("/allowed")
     public Mono<AllowedUserResponse> isAllowedUser(@RequestParam(value = "queueName", defaultValue = "default") final String queueName,
+                                                   @RequestParam(name = "token") String token,
                                                    @RequestParam("userId") final Long userId) {
-        return userQueueService.isAllowed(queueName, userId).map(AllowedUserResponse::new);
+        return userQueueService.isAllowedByToken(queueName, userId, token).map(AllowedUserResponse::new);
     }
 
     @GetMapping("/rank")

--- a/module/web/src/main/java/cwchoiit/ticketing/web/controller/SiteController.java
+++ b/module/web/src/main/java/cwchoiit/ticketing/web/controller/SiteController.java
@@ -1,13 +1,64 @@
 package cwchoiit.ticketing.web.controller;
 
+import cwchoiit.ticketing.web.response.AllowedUserResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Arrays;
 
 @Controller
 public class SiteController {
 
+    private final RestTemplate restTemplate = new RestTemplate();
+
     @GetMapping("/")
-    public String index() {
+    public String index(@RequestParam(name = "queueName", defaultValue = "default") String queueName,
+                        @RequestParam("userId") Long userId,
+                        HttpServletRequest request) {
+
+        String token = getTokenByCookie(queueName, request);
+
+        URI uri = UriComponentsBuilder.fromUriString("http://127.0.0.1:9001")
+                .path("/api/v1/queue/allowed")
+                .queryParam("queueName", queueName)
+                .queryParam("userId", userId)
+                .queryParam("token", token)
+                .encode()
+                .build()
+                .toUri();
+
+        ResponseEntity<AllowedUserResponse> response = restTemplate.getForEntity(uri, AllowedUserResponse.class);
+        if (response.getBody() == null || !response.getBody().allowed()) {
+            return "redirect:http://127.0.0.1:9001/waiting-room?userId=%d&redirectUrl=%s"
+                    .formatted(
+                            userId,
+                            "http://127.0.0.1:9000?userId=%d".formatted(userId)
+                    );
+        }
+
         return "index";
+    }
+
+    private String getTokenByCookie(String queueName, HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        String cookieName = "user-queue-%s-token".formatted(queueName);
+
+        if (cookies != null) {
+            return Arrays.stream(cookies)
+                    .filter(cookie -> cookie.getName().equalsIgnoreCase(cookieName))
+                    .findFirst()
+                    .orElseGet(() -> new Cookie(cookieName, ""))
+                    .getValue();
+        }
+        return "";
     }
 }

--- a/module/web/src/main/java/cwchoiit/ticketing/web/response/AllowedUserResponse.java
+++ b/module/web/src/main/java/cwchoiit/ticketing/web/response/AllowedUserResponse.java
@@ -1,0 +1,4 @@
+package cwchoiit.ticketing.web.response;
+
+public record AllowedUserResponse(Boolean allowed) {
+}


### PR DESCRIPTION
- 1. 최초 타겟 페이지 접근
- 2. 해당 유저가 대기열에 들어갈 필요가 없다면 바로 티켓팅 페이지로 이동
- 3. 해당 유저가 대기열에 들어가야 하면 대기열 화면으로 이동
- 4. 대기열 화면에서는 지속적으로 해당 유저의 접속 허용 체크
- 5. 접속이 허용된다면 다시 타겟 페이지로 리다이렉트
